### PR TITLE
docs: 邮件内容添加对超链接说明

### DIFF
--- a/README-en.md
+++ b/README-en.md
@@ -109,8 +109,10 @@ directMail
 [⬆Back to Top](#table-of-contents)
 
 ## Attention
+- `HtmlBody` Or `TextBody` cannot contain the brackets `()` of the English input method, otherwise the signature will not pass.
+- Please only type your link by text when you need hyperlink, DON'T USE "ADD LINK" TOOL.
 
-`HtmlBody` Or `TextBody` cannot contain the brackets `()` of the English input method, otherwise the signature will not pass.<br />In short, it is best not to have English input method special characters in the mail content.<br />[⬆Back to Top](#table-of-contents)
+In short, it is best not to have English input method special characters in the mail content.<br />[⬆Back to Top](#table-of-contents)
 
 ## Reference
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ directMail
 [⬆ Back to Top](#table-of-contents)
 
 ## Attention
-`HtmlBody` 或 `TextBody` 不能出现英文输入法的括号 ()，否则会请求400，出现报错`SignatureDoesNotMatch`。
+- `HtmlBody` 或 `TextBody` 不能出现英文输入法的括号 ()，否则会请求400，出现报错`SignatureDoesNotMatch`。
+- 当需要超链接时请直接以文本形式写下链接，不需要使用“添加链接”工具
 
 总之，邮件内容最好不要出现英文输入法的特殊字符。
 


### PR DESCRIPTION
## Why
最近一次使用发现使用超链接(\<a\>)无法发送邮件，实际上邮件发送时会自动转换链接，不需要编写时自行添加，故修改`README.md`。

## How
添加超链接使用说明

## Docs
- `README.md`
- `README-en.md`
